### PR TITLE
Fix npm start script

### DIFF
--- a/app/webpack.dev.config.ts
+++ b/app/webpack.dev.config.ts
@@ -3,7 +3,7 @@ import HtmlWebpackPlugin from "html-webpack-plugin";
 import ForkTsCheckerWebpackPlugin from "fork-ts-checker-webpack-plugin";
 import ESLintPlugin from "eslint-webpack-plugin";
 
-const config: Configuration = {
+const config = {
     mode: "development",
     output: {
         publicPath: "/",


### PR DESCRIPTION
Remove typing of webpack config object to avoid a type error when using the dev webpack config.