### PR TITLE
Improvements to metrics collection

### DIFF
--- a/service/Controllers/SessionController.cs
+++ b/service/Controllers/SessionController.cs
@@ -44,7 +44,7 @@ namespace Spacecowboy.Service.Controllers
     [ApiController]
     public class SessionController : ControllerBase
     {
-        private static readonly Gauge sessionsCreated = Metrics.CreateGauge("spacecowboy_sessions_total", "Accumulated number of session creatied");
+        private static readonly Counter sessionsCreated = Metrics.CreateCounter("spacecowboy_sessions_total", "Accumulated number of session creatied");
         private static readonly Gauge sessionsCurrent = Metrics.CreateGauge("spacecowboy_sessions_current", "Number of active sessions");
         private static readonly Counter participantsTotal = Metrics.CreateCounter("spacecowboy_participants_total", "Accumulated number of participants across all sessions created",
             new CounterConfiguration
@@ -218,12 +218,10 @@ namespace Spacecowboy.Service.Controllers
             try
             {
                 await repository.AddSessionAsync(new Session(sessionId));
-                var metrics = await repository.GetMetrics();
-                log.LogInformation("Created session {SessionId}, a total of {TotalSessions} sessions so far", sessionId, metrics.TotalSessions);
-                sessionsCreated.Set(metrics.TotalSessions);
+                log.LogInformation("Created session {SessionId}", sessionId);
+                sessionsCreated.Inc();
                 sessionsCurrent.Inc();
                 return Created("", new SessionResponse(await repository.GetSessionAsync(sessionId)));
-
             }
             catch (SessionExistsException)
             {

--- a/service/Controllers/SessionController.cs
+++ b/service/Controllers/SessionController.cs
@@ -27,7 +27,6 @@ using Spacecowboy.Service.Controllers.Hubs;
 using Spacecowboy.Service.Model;
 using Swashbuckle.AspNetCore.Annotations;
 using System;
-using System.ComponentModel.DataAnnotations;
 using System.Linq;
 using System.Threading.Tasks;
 

--- a/service/Startup.cs
+++ b/service/Startup.cs
@@ -26,6 +26,7 @@ using Spacecowboy.Service.Controllers.Hubs;
 using Spacecowboy.Service.Infrastructure;
 using Spacecowboy.Service.Model;
 using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Text.Json.Serialization;
 
@@ -111,7 +112,22 @@ namespace Spacecowboy.Service
                 );
             });
 
+            /* Set the service instance name as a label on all metrics published. */
+            var instanceName = serviceOptions["InstanceName"];
+            if (instanceName != null)
+            {
+                Metrics.DefaultRegistry.SetStaticLabels(new Dictionary<string, string>
+                {
+                  { "instance_name", instanceName }
+                });
+                Log.Information("Metrics will be annotated with instance name {instanceName}", instanceName);
+            }
+            else
+            {
+                Log.Information("No instance name configured");
+            }
         }
+
 
         // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.
         public void Configure(IApplicationBuilder app, IWebHostEnvironment env)


### PR DESCRIPTION
* Do not attempt to capture the total number of sessions ever created with the spacecowboy_sessions_total metric, instead capture the number of sessions started since the instance started.
* Add static dimension instance_name to all metrics. This makes it possible to collect metrics from multiple replicated service instances.