### PR TITLE
Upgrade service to .net 8

### DIFF
--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -3,10 +3,9 @@ services:
   spacecowboys-service:
     environment:
       ASPNETCORE_ENVIRONMENT: "Development"
-      ASPNETCORE_URLS: "https://+:443;http://+:80"
     env_file: .env
     ports:
-      - 5000:80
+      - 5000:8080
     volumes:
       - ${APPDATA}/Microsoft/UserSecrets:/root/.microsoft/usersecrets:ro
       - ${APPDATA}/ASP.NET/Https:/root/.aspnet/https:ro


### PR DESCRIPTION
- Update compose to use the new default .net container port.
- Update reference to service submodule for service [PR #3](https://github.com/spacecowboy-app/spacecowboy-service/pull/3).
