### PR TITLE
Use an authorization token to push container images

### DIFF
--- a/.github/workflows/service.yml
+++ b/.github/workflows/service.yml
@@ -79,6 +79,8 @@ jobs:
         context: service/src
         push: true
         tags: ghcr.io/spacecowboy-app/spacecowboy-service:latest
+        secrets: |
+          GIT_AUTH_TOKEN=${{ secrets.CONTAINER_PUSH_SECRET }}
         labels: |
           org.opencontainers.image.source=${{ github.repository }}
           org.opencontainers.image.description=Spacecowboy service backend


### PR DESCRIPTION
The workflow cannot access the the container repo without special authorization.